### PR TITLE
feat: allow to check for more Keycloak issuers

### DIFF
--- a/keycloak/src/main/java/com/avast/grpc/jwt/keycloak/server/IssuersCheck.java
+++ b/keycloak/src/main/java/com/avast/grpc/jwt/keycloak/server/IssuersCheck.java
@@ -5,19 +5,24 @@ import org.keycloak.common.VerificationException;
 import org.keycloak.representations.JsonWebToken;
 
 public class IssuersCheck implements TokenVerifier.Predicate<JsonWebToken> {
-    private final String[] issuers;
+  private final String[] issuers;
 
-    public IssuersCheck(String[] issuers) {
-        this.issuers = issuers;
-    }
+  public IssuersCheck(String[] issuers) {
+    this.issuers = issuers;
+  }
 
-    @Override
-    public boolean test(JsonWebToken t) throws VerificationException {
-        for (String i: issuers) {
-            if (i.equals(t.getIssuer())) {
-                return true;
-            }
-        }
-        throw new VerificationException("Invalid token issuer. Was '" + t.getIssuer() + "' but expected one of: " + String.join(" ", issuers));
+  @Override
+  public boolean test(JsonWebToken t) throws VerificationException {
+    for (String i : issuers) {
+      if (i.equals(t.getIssuer())) {
+        return true;
+      }
     }
-};
+    throw new VerificationException(
+        "Invalid token issuer. Was '"
+            + t.getIssuer()
+            + "' but expected one of: "
+            + String.join(" ", issuers));
+  }
+}
+;

--- a/keycloak/src/main/java/com/avast/grpc/jwt/keycloak/server/IssuersCheck.java
+++ b/keycloak/src/main/java/com/avast/grpc/jwt/keycloak/server/IssuersCheck.java
@@ -1,0 +1,23 @@
+package com.avast.grpc.jwt.keycloak.server;
+
+import org.keycloak.TokenVerifier;
+import org.keycloak.common.VerificationException;
+import org.keycloak.representations.JsonWebToken;
+
+public class IssuersCheck implements TokenVerifier.Predicate<JsonWebToken> {
+    private final String[] issuers;
+
+    public IssuersCheck(String[] issuers) {
+        this.issuers = issuers;
+    }
+
+    @Override
+    public boolean test(JsonWebToken t) throws VerificationException {
+        for (String i: issuers) {
+            if (i.equals(t.getIssuer())) {
+                return true;
+            }
+        }
+        throw new VerificationException("Invalid token issuer. Was '" + t.getIssuer() + "' but expected one of: " + String.join(" ", issuers));
+    }
+};

--- a/keycloak/src/main/java/com/avast/grpc/jwt/keycloak/server/KeycloakJwtServerInterceptor.java
+++ b/keycloak/src/main/java/com/avast/grpc/jwt/keycloak/server/KeycloakJwtServerInterceptor.java
@@ -24,7 +24,10 @@ public class KeycloakJwtServerInterceptor extends JwtServerInterceptor<AccessTok
             Clock.systemUTC());
     KeycloakJwtTokenParser tokenParser =
         new KeycloakJwtTokenParser(
-            fc.getString("serverUrl"), fc.getString("realm"), fc.getStringList("allowedIssuers"), publicKeyProvider);
+            fc.getString("serverUrl"),
+            fc.getString("realm"),
+            fc.getStringList("allowedIssuers"),
+            publicKeyProvider);
     tokenParser = tokenParser.withExpectedAudience(fc.getString("expectedAudience"));
     tokenParser = tokenParser.withExpectedIssuedFor(fc.getString("expectedIssuedFor"));
     return new KeycloakJwtServerInterceptor(tokenParser);

--- a/keycloak/src/main/java/com/avast/grpc/jwt/keycloak/server/KeycloakJwtServerInterceptor.java
+++ b/keycloak/src/main/java/com/avast/grpc/jwt/keycloak/server/KeycloakJwtServerInterceptor.java
@@ -24,7 +24,7 @@ public class KeycloakJwtServerInterceptor extends JwtServerInterceptor<AccessTok
             Clock.systemUTC());
     KeycloakJwtTokenParser tokenParser =
         new KeycloakJwtTokenParser(
-            fc.getString("serverUrl"), fc.getString("realm"), publicKeyProvider);
+            fc.getString("serverUrl"), fc.getString("realm"), fc.getStringList("allowedIssuers"), publicKeyProvider);
     tokenParser = tokenParser.withExpectedAudience(fc.getString("expectedAudience"));
     tokenParser = tokenParser.withExpectedIssuedFor(fc.getString("expectedIssuedFor"));
     return new KeycloakJwtServerInterceptor(tokenParser);

--- a/keycloak/src/main/java/com/avast/grpc/jwt/keycloak/server/KeycloakJwtTokenParser.java
+++ b/keycloak/src/main/java/com/avast/grpc/jwt/keycloak/server/KeycloakJwtTokenParser.java
@@ -2,16 +2,15 @@ package com.avast.grpc.jwt.keycloak.server;
 
 import com.avast.grpc.jwt.server.JwtTokenParser;
 import com.google.common.base.Strings;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.stream.Collectors;
 import org.keycloak.TokenVerifier;
 import org.keycloak.common.VerificationException;
 import org.keycloak.constants.ServiceUrlConstants;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.util.TokenUtil;
-
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
-import java.util.stream.Collectors;
 
 public class KeycloakJwtTokenParser implements JwtTokenParser<AccessToken> {
 
@@ -21,11 +20,15 @@ public class KeycloakJwtTokenParser implements JwtTokenParser<AccessToken> {
   protected String expectedIssuedFor;
 
   public KeycloakJwtTokenParser(
-          String serverUrl, String realm, List<String> allowedIssuers, KeycloakPublicKeyProvider publicKeyProvider) {
+      String serverUrl,
+      String realm,
+      List<String> allowedIssuers,
+      KeycloakPublicKeyProvider publicKeyProvider) {
     this.publicKeyProvider = publicKeyProvider;
 
     String suffix = ServiceUrlConstants.REALM_INFO_PATH.replace("{realm-name}", realm);
-    List<String> issuers = allowedIssuers.stream().map(i -> i + suffix).collect(Collectors.toList());
+    List<String> issuers =
+        allowedIssuers.stream().map(i -> i + suffix).collect(Collectors.toList());
     issuers.add(0, serverUrl + suffix);
     this.checks =
         new TokenVerifier.Predicate[] {

--- a/keycloak/src/main/resources/reference.conf
+++ b/keycloak/src/main/resources/reference.conf
@@ -10,6 +10,7 @@ keycloakDefaults {
   // for server
   expectedAudience = ""
   expectedIssuedFor = ""
+  allowedIssuers = [] // list of additional allowed issuers, e.g. "https://sso-new.example.com/auth"
   minTimeBetweenJwksRequests = 10 seconds
   publicKeyCacheTtl = 1 day
 }


### PR DESCRIPTION
This is required when a Keycloak instance is being migrated from one hostname to another.